### PR TITLE
chore: add Volta Node version config and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ nvm use 22.14.0
 npm install
 ```
 
+> ℹ️ This project uses [Volta](https://volta.sh/) to automatically manage the Node version (example `22.19.0`). If you have Volta installed, the correct version will be used without any manual intervention.
+
 ### Development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "prettier-plugin-tailwindcss": "^0.6.14",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "volta": {
+    "node": "22.19.0"
   }
 }


### PR DESCRIPTION
## Add Volta Node Version Management

- Added a `volta` section in `package.json` to specify the required Node.js version (`22.19.0`) for the project.
- Updated the `README.md` to mention that Volta is used to automatically manage the Node version, ensuring consistency for all contributors.

This makes it easier for developers to use the correct Node.js version without manual intervention if they have Volta installed.